### PR TITLE
chore: add topics to pubspec.yaml

### DIFF
--- a/slick_slides/pubspec.yaml
+++ b/slick_slides/pubspec.yaml
@@ -2,6 +2,9 @@ name: slick_slides
 description: Create a nice looking presentations in Flutter with animations and code. Intended for techical talks and videos.
 version: 0.2.0
 repository: https://github.com/serverpod/slick_slides
+topics:
+  - presentation
+  - slides
 
 environment:
   sdk: '>=3.0.5 <4.0.0'


### PR DESCRIPTION
Adds "presentation" and "slides" topics to the `pubspec.yaml` file so that the package could be easily discoverable along with the other similar packages on [pub.dev](https://pub.dev/).