### PR TITLE
Returned accidentally deleted import

### DIFF
--- a/slick_slides/lib/src/deck/theme.dart
+++ b/slick_slides/lib/src/deck/theme.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 const _defaultAudioPaddingDuration = Duration(seconds: 1);


### PR DESCRIPTION
I found that version `0.2.2` has deleted import. How result, project cannot build. You can revert this changes or apply this pull requests.

![Screenshot 2024-05-07 at 15 03 39](https://github.com/serverpod/slick_slides/assets/30602586/c6857962-95b9-4ec7-8de3-755f8dc7e681)


```
../../../.pub-cache/hosted/pub.dev/slick_slides-0.2.2/lib/src/deck/theme.dart:89:11: Error: Method not found: 'FontVariation'.
          FontVariation('wght', 600),
          ^^^^^^^^^^^^^
../../../.pub-cache/hosted/pub.dev/slick_slides-0.2.2/lib/src/deck/theme.dart:165:9: Error: Method not found: 'FontVariation'.
        FontVariation('wght', 800),
        ^^^^^^^^^^^^^
../../../.pub-cache/hosted/pub.dev/slick_slides-0.2.2/lib/src/deck/theme.dart:183:9: Error: Method not found: 'FontVariation'.
        FontVariation('wght', 600),
        ^^^^^^^^^^^^^
../../../.pub-cache/hosted/pub.dev/slick_slides-0.2.2/lib/src/deck/theme.dart:194:9: Error: Method not found: 'FontVariation'.
        FontVariation('wght', 400),
        ^^^^^^^^^^^^^
../../../.pub-cache/hosted/pub.dev/slick_slides-0.2.2/lib/src/deck/theme.dart:203:9: Error: Method not found: 'FontVariation'.
        FontVariation('wght', 400),
        ^^^^^^^^^^^^^
../../../.pub-cache/hosted/pub.dev/slick_slides-0.2.2/lib/src/deck/theme.dart:216:9: Error: Method not found: 'FontVariation'.
        FontVariation('wght', 800),
        ^^^^^^^^^^^^^
../../../.pub-cache/hosted/pub.dev/slick_slides-0.2.2/lib/src/deck/theme.dart:234:9: Error: Method not found: 'FontVariation'.
        FontVariation('wght', 600),
        ^^^^^^^^^^^^^
../../../.pub-cache/hosted/pub.dev/slick_slides-0.2.2/lib/src/deck/theme.dart:245:9: Error: Method not found: 'FontVariation'.
        FontVariation('wght', 400),
        ^^^^^^^^^^^^^
../../../.pub-cache/hosted/pub.dev/slick_slides-0.2.2/lib/src/deck/theme.dart:254:9: Error: Method not found: 'FontVariation'.
        FontVariation('wght', 400),
        ^^^^^^^^^^^^^
Failed to compile application.

```